### PR TITLE
Cassandra cluster connection configuration

### DIFF
--- a/keystone/assignment/backends/cass.py
+++ b/keystone/assignment/backends/cass.py
@@ -22,7 +22,6 @@ from keystone import exception
 from keystone.i18n import _
 
 from cassandra.cqlengine import columns
-from cassandra.cqlengine import connection
 from cassandra.cqlengine.query import BatchQuery
 from cassandra.cqlengine.management import sync_table
 from cassandra.cqlengine.query import BatchType, DoesNotExist
@@ -430,5 +429,5 @@ class RoleAssignment(cass.ExtrasModel):
     role_id = columns.Text(primary_key=True, index=True, max_length=64)
     inherited = columns.Boolean(default=False, required=True, index=True)
 
-connection.setup(cass.ips, cass.keyspace)
+cass.connect_to_cluster(cass.ips, cass.keyspace)
 sync_table(RoleAssignment)

--- a/keystone/credential/backends/cass.py
+++ b/keystone/credential/backends/cass.py
@@ -17,7 +17,6 @@ from keystone import credential
 from keystone import exception
 
 from cassandra.cqlengine import columns
-from cassandra.cqlengine import connection
 from cassandra.cqlengine.query import BatchQuery
 from cassandra.cqlengine.management import sync_table
 from cassandra.cqlengine.query import BatchType
@@ -30,7 +29,7 @@ class CredentialModel(cass.ExtrasModel):
     type = columns.Text(max_length=255)
     extra = columns.Text(default='')
 
-connection.setup(cass.ips, cass.keyspace)
+cass.connect_to_cluster(cass.ips, cass.keyspace)
 
 sync_table(CredentialModel)
 

--- a/keystone/identity/backends/cass.py
+++ b/keystone/identity/backends/cass.py
@@ -21,7 +21,6 @@ from keystone.common import utils
 from keystone.i18n import _
 
 from cassandra.cqlengine import columns
-from cassandra.cqlengine import connection
 from cassandra.cqlengine.management import sync_table
 from cassandra.cqlengine.models import Model
 from cassandra.cqlengine.query import BatchType, DoesNotExist
@@ -83,7 +82,7 @@ class GroupMembership(cass.ExtrasModel):
     group_id = columns.Text(primary_key=True, max_length=64)
     user_id = columns.Text(primary_key=True, clustering_order="DESC", max_length=64)
 
-connection.setup(cass.ips, cass.keyspace)
+cass.connect_to_cluster(cass.ips, cass.keyspace)
 
 sync_table(User)
 sync_table(DomainIdUserNameToUserId)


### PR DESCRIPTION
Snippets from Yogeshwar's email:
1. We want to use the "data center aware round robin policy" wrapped by the "token aware policy".
2. To begin with, let's have all reads and writes use the CL of LOCAL_QUORUM. In case of failures, let's have them retry with QUORUM. This involves implementing our own retry policy where we override the "onUnavailable" event, and issue one retry with QUORUM. Let's not retry more than once to begin with. If things are already going bad that neither LOCAL_QUORUM nor QUORUM CL is succeeding, maybe we will make things just worse by retrying with a lower CL.
